### PR TITLE
feat: sql script to seed many good looking records

### DIFF
--- a/dev-tools/local-supabase/sql/seed.sql
+++ b/dev-tools/local-supabase/sql/seed.sql
@@ -92,8 +92,8 @@ tss as (
     (random() - 0.5) * 0.1 + 1 as change
   from
     generate_series(
-      '2020-12-01'::timestamptz,
-      '2021-02-01'::timestamptz,
+      (select now() - interval '60 days')::timestamptz,
+      (select now())::timestamptz,
       '1 hour'::interval
     ) as ts
 ) 


### PR DESCRIPTION
In this PR i am adding a script that adds realistic looking records into the DB.
the first_value is the starting value for the series
tss is a table that contains an id, ts which is the timestamp generated, and change which is a percent between 0.9 and 1.1
i then insert into a random device id the timestamps generated and the measurement wrapped into an array
the way I get the current value in the series is by multiplying together all the past change values eg

1. measurment = [1.1]
2. measurment = [1.1*1.02]
3. measurment = [1.1*1.02*0.97]

since postgres doesnt provide a product function we have to use the properties of logs -> e^(log(1.1)+log(1.02)) = 1.1*1.02
also we get the past aggregate values for sum by using the over() function 